### PR TITLE
✨(circle) add a hub job to push a built image on docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,71 @@ jobs:
           name: Check built image availability
           command: docker images edxec
 
+  # ---- DockerHub publication job ----
+  hub:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    working_directory: ~/fun
+    steps:
+      - checkout
+      # Activate docker-in-docker (with layers caching enabled)
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build production image
+          command: make build
+
+      # Login to DockerHub to Publish new images
+      #
+      # Nota bene: you'll need to define the following secrets environment vars
+      # in CircleCI interface:
+      #
+      #   - DOCKER_USER
+      #   - DOCKER_PASS
+      - run:
+          name: Login to DockerHub
+          command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+
+      # Tag docker image with the same pattern used in Git (Semantic Versioning)
+      #
+      # Git tag: v1.0.1
+      # Docker tag: 1.0.1
+      - run:
+          name: Tag image
+          command: |
+            docker images fundocker/edxec
+            DOCKER_TAG=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v//')
+            RELEASE_TYPE=$([[ -z "$CIRCLE_TAG" ]] && echo "branch" || echo "tag ")
+            # Display either:
+            # - DOCKER_TAG: master (Git branch)
+            # or
+            # - DOCKER_TAG: 1.1.2 (Git tag v1.1.2)
+            echo "DOCKER_TAG: ${DOCKER_TAG} (Git ${RELEASE_TYPE}${CIRCLE_TAG})"
+            docker tag edxec:${CIRCLE_SHA1} fundocker/edxec:${DOCKER_TAG}
+            if [[ -n "$CIRCLE_TAG" ]]; then
+              docker tag edxec:${CIRCLE_SHA1} fundocker/edxec:latest
+            fi
+            docker images | grep -E "^fundocker/edxec\s*(${DOCKER_TAG}.*|latest|master)"
+      # Publish images to DockerHub
+      #
+      # Nota bene: logged user (see "Login to DockerHub" step) must have write
+      # permission for the project's repository; this also implies that the
+      # DockerHub repository already exists.
+      - run:
+          name: Publish images
+          command: |
+            DOCKER_TAG=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v//')
+            RELEASE_TYPE=$([[ -z "$CIRCLE_TAG" ]] && echo "branch" || echo "tag ")
+            # Display either:
+            # - DOCKER_TAG: master (Git branch)
+            # or
+            # - DOCKER_TAG: 1.1.2 (Git tag v1.1.2)
+            echo "DOCKER_TAG: ${DOCKER_TAG} (Git ${RELEASE_TYPE}${CIRCLE_TAG})"
+            docker push fundocker/edxec:${DOCKER_TAG}
+            if [[ -n "$CIRCLE_TAG" ]]; then
+              docker push fundocker/edxec:latest
+            fi
+
 workflows:
   version: 2
 
@@ -107,3 +172,14 @@ workflows:
             tags:
               only: /.*/
 
+      # DockerHub publication.
+      #
+      # Publish docker images only if all build
+      - hub:
+          requires:
+            - build-docker
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@ release.
 
 - First draft of the OpenEdx E-Commerce service docker image (target release
   defaults to the `master` branch)
+- Job on CircleCI to publish images on DockerHub
 
 [unreleased]: https://github.com/openfun/openedx-docker


### PR DESCRIPTION
### Purpose

When a branch is merged on master or when a new tag is created we want
to push on docker hub a new image corresponding to the newly created tag
or master branch.

### Proposal

- [x] create a hub job on circleci