### PR TITLE
🐛(circleci) set EDX_EC_DOCKER_TAG before building the image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,9 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Build production image
-          command: make build
+          command: |
+            export EDX_EC_DOCKER_TAG=${CIRCLE_SHA1}
+            make build
 
       # Login to DockerHub to Publish new images
       #


### PR DESCRIPTION
### Purpose

To be sure to have a unique docker image built on each circle job we use
a sha1 provided by circleci. But we forget to set the variable
EDX_EC_DOCKER_TAG before running `make build` and then the image to tag
was not existing.

### Proposal

- [x] set `EDX_EC_DOCKER_TAG` before running `make build`