### PR TITLE
Add release factory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,56 @@
 version: 2
+
+# Templates
+defaults: &defaults # We use the machine executor, i.e. a VM, not a container
+  machine:
+    # Cache docker layers so that we strongly speed up this job execution
+    # This cache will be available to future jobs (although because jobs run
+    # in parallel, CircleCI does not guarantee that a given job will see a
+    # specific version of the cache. See documentation for details)
+    docker_layer_caching: true
+
+  working_directory: ~/fun
+
+build_steps: &build_steps
+  steps:
+    # Checkout openedx-docker sources
+    - checkout
+
+    # Skip release build & testing if changes are not targeting it
+    - run:
+        name: Check if changes are targeting the current release
+        command: bin/ci checkpoint
+
+    # Install a recent docker-compose release
+    - run:
+        name: Upgrade docker-compose
+        command: |
+          curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+          chmod +x ~/docker-compose
+          sudo mv ~/docker-compose /usr/local/bin/docker-compose
+
+    # Production image build. It will be tagged as edxapp:latest
+    - run:
+        name: Build production image
+        command: |
+          source $(bin/ci activate_path)
+          make build
+
+    # Bootstrap
+    - run:
+        name: Bootstrap the app
+        command: |
+          source $(bin/ci activate_path)
+          make dev-assets
+          make migrate
+
+    # Check that the production build starts
+    - run:
+        name: Start development server
+        command: |
+          source $(bin/ci activate_path)
+          make dev
+
 jobs:
   # Git jobs
   # Check that the git history is clean and complies with our expectations
@@ -53,135 +105,108 @@ jobs:
             # Get the longuest line width (ignoring release links)
             test $(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com/openfun" | wc -L) -le 80
 
-  # ---- Docker jobs ----
-  # Build the Docker image ready for production
-  build-docker:
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    working_directory: ~/fun
-    steps:
-      # Checkout repository sources
-      - checkout
-      # Activate docker-in-docker (with layers caching enabled)
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Build production image
-          command: make build
-      - run:
-          name: Check built image availability
-          command: docker images edxec
+  # Build jobs
+  #
+  # Note that the job name should match the EDX_EC_RELEASE value
+  master-bare:
+    <<: [*defaults, *build_steps]
 
-  # ---- DockerHub publication job ----
+  dogwood.3-fun:
+    <<: [*defaults, *build_steps]
+
+  # Hub job
   hub:
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    working_directory: ~/fun
+    <<: *defaults
+
     steps:
       - checkout
-      # Activate docker-in-docker (with layers caching enabled)
-      - setup_remote_docker:
-          docker_layer_caching: true
+
+      # Install a recent docker-compose release
       - run:
-          name: Build production image
+          name: Upgrade docker-compose
           command: |
-            export EDX_EC_DOCKER_TAG=${CIRCLE_SHA1}
+            curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+            chmod +x ~/docker-compose
+            sudo mv ~/docker-compose /usr/local/bin/docker-compose
+
+      # Thanks to docker layer caching, rebuilding the image should be blazing
+      # fast!
+      - run:
+          name: Rebuild production image
+          command: |
+            source $(bin/ci activate_path)
             make build
 
-      # Login to DockerHub to Publish new images
-      #
-      # Nota bene: you'll need to define the following secrets environment vars
-      # in CircleCI interface:
-      #
-      #   - DOCKER_USER
-      #   - DOCKER_PASS
+      # Tag images with our DockerHub namespace (fundocker/), and list images to
+      # check that they have been properly tagged.
+      - run:
+          name: Tag production image
+          command: |
+            source $(bin/ci activate_path)
+            docker tag edxec:${EDX_EC_DOCKER_TAG} fundocker/edxec:${CIRCLE_TAG}
+            docker images fundocker/edxec:${CIRCLE_TAG}
+
+      # Login to DockerHub with encrypted credentials stored as secret
+      # environment variables (set in CircleCI project settings)
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 
-      # Tag docker image with the same pattern used in Git (Semantic Versioning)
-      #
-      # Git tag: v1.0.1
-      # Docker tag: 1.0.1
+      # Publish the production image to DockerHub
       - run:
-          name: Tag image
+          name: Publish production image
           command: |
-            docker images fundocker/edxec
-            DOCKER_TAG=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v//')
-            RELEASE_TYPE=$([[ -z "$CIRCLE_TAG" ]] && echo "branch" || echo "tag ")
-            # Display either:
-            # - DOCKER_TAG: master (Git branch)
-            # or
-            # - DOCKER_TAG: 1.1.2 (Git tag v1.1.2)
-            echo "DOCKER_TAG: ${DOCKER_TAG} (Git ${RELEASE_TYPE}${CIRCLE_TAG})"
-            docker tag edxec:${CIRCLE_SHA1} fundocker/edxec:${DOCKER_TAG}
-            if [[ -n "$CIRCLE_TAG" ]]; then
-              docker tag edxec:${CIRCLE_SHA1} fundocker/edxec:latest
-            fi
-            docker images | grep -E "^fundocker/edxec\s*(${DOCKER_TAG}.*|latest|master)"
-      # Publish images to DockerHub
-      #
-      # Nota bene: logged user (see "Login to DockerHub" step) must have write
-      # permission for the project's repository; this also implies that the
-      # DockerHub repository already exists.
-      - run:
-          name: Publish images
-          command: |
-            DOCKER_TAG=$([[ -z "$CIRCLE_TAG" ]] && echo $CIRCLE_BRANCH || echo ${CIRCLE_TAG} | sed 's/^v//')
-            RELEASE_TYPE=$([[ -z "$CIRCLE_TAG" ]] && echo "branch" || echo "tag ")
-            # Display either:
-            # - DOCKER_TAG: master (Git branch)
-            # or
-            # - DOCKER_TAG: 1.1.2 (Git tag v1.1.2)
-            echo "DOCKER_TAG: ${DOCKER_TAG} (Git ${RELEASE_TYPE}${CIRCLE_TAG})"
-            docker push fundocker/edxec:${DOCKER_TAG}
-            if [[ -n "$CIRCLE_TAG" ]]; then
-              docker push fundocker/edxec:latest
-            fi
+            docker push fundocker/edxec:${CIRCLE_TAG}
 
 workflows:
   version: 2
 
   ecommerce:
     jobs:
-
-      # Git jobs
-      #
-      # Check validity of git history
+      # Quality
       - lint-git:
           filters:
+            branches:
+              ignore: master
             tags:
-              only: /.*/
-      # Check CHANGELOG update
+              ignore: /.*/
       - check-changelog:
           filters:
             branches:
               ignore: master
             tags:
-              only: /(?!^v).*/
+              ignore: /.*/
       - lint-changelog:
           filters:
             branches:
               ignore: master
             tags:
-              only: /.*/
+              ignore: /.*/
 
-      # Docker jobs
-      #
-      # Build images
-      - build-docker:
+      # Build jobs
+      - master-bare:
           filters:
             tags:
-              only: /.*/
+              ignore: /.*/
+      - dogwood.3-fun:
+          filters:
+            tags:
+              ignore: /.*/
 
-      # DockerHub publication.
+      # We are pushing to Docker only images that are the result of a tag respecting the pattern:
+      #    **{branch-name}-x.y.z**
       #
-      # Publish docker images only if all build
+      # Where branch-name is of the form: **{edx-version}[-{fork-name}]**
+      #   - **edx-version:** name of the upstream `edx-platform` version (e.g. ginkgo.1),
+      #   - **fork-name:** name of the specific project fork, if any (e.g. funwb).
+      #
+      # Some valid examples:
+      #   - dogwood.3-1.0.3
+      #   - dogwood.2-funmooc-17.6.1
+      #   - eucalyptus-funwb-2.3.19
       - hub:
-          requires:
-            - build-docker
           filters:
             branches:
-              only: master
+              ignore: /.*/
             tags:
-              only: /^v.*/
+              only: /^[a-z0-9.]*-?[a-z]*-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
 
   # Build jobs
   #
-  # Note that the job name should match the EDX_EC_RELEASE value
+  # Note that the job name should match the EDXEC_RELEASE value
   master-bare:
     <<: [*defaults, *build_steps]
 
@@ -143,7 +143,7 @@ jobs:
           name: Tag production image
           command: |
             source $(bin/ci activate_path)
-            docker tag edxec:${EDX_EC_DOCKER_TAG} fundocker/edxec:${CIRCLE_TAG}
+            docker tag edxec:${EDXEC_DOCKER_TAG} fundocker/edxec:${CIRCLE_TAG}
             docker images fundocker/edxec:${CIRCLE_TAG}
 
       # Login to DockerHub with encrypted credentials stored as secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-data
-src
+# Releases sources, statics and media
+data/
+src/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,11 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+As the tooling part of this repository is not intended to get released, all
+notable changes to this project will be documented in each flavored OpenEdx
+E-Commerce release directory.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic
-Versioning](https://semver.org/spec/v2.0.0.html) for each flavored OpenEdx
-release.
+You can list (and possibly read) them using the following shell command:
 
-## [Unreleased]
-
-### Added
-
-- First draft of the OpenEdx E-Commerce service docker image (target release
-  defaults to the `master` branch)
-- Job on CircleCI to publish images on DockerHub
-
-[unreleased]: https://github.com/openfun/openedx-docker
+```bash
+$ find releases -maxdepth 4 -name CHANGELOG.md
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,9 @@ COPY --from=front-builder /home/node/ecommerce/static /app/ecommerce/static
 # container, so we should override it in our ECOMMERCE_CFG file.
 COPY ./docker/files/usr/local/etc/ecommerce /usr/local/etc/ecommerce
 ENV ECOMMERCE_CFG /usr/local/etc/ecommerce/local.yaml
+# The update_assets management command is not implemented in old releases, we
+# ignore its call failure for backward-compatibility as assets have already
+# been build in a previous stage in this case.
 RUN python manage.py update_assets --skip-collect --settings=ecommerce.settings.production || \
       echo "Assets update failed and will be ignored (old release)"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
 
 # E-Commerce release archive url to build our image with
-ARG EDX_EC_ARCHIVE_URL=https://github.com/edx/ecommerce/archive/master.tar.gz
+ARG EDXEC_ARCHIVE_URL=https://github.com/edx/ecommerce/archive/master.tar.gz
 
 # ---- Base image to inherit from ----
 FROM python:2.7-stretch as base
@@ -20,8 +20,8 @@ RUN apt-get update && \
     apt-get install -y curl
 
 # Download ecommerce release
-ARG EDX_EC_ARCHIVE_URL
-RUN curl -sLo ecommerce.tgz ${EDX_EC_ARCHIVE_URL} && \
+ARG EDXEC_ARCHIVE_URL
+RUN curl -sLo ecommerce.tgz ${EDXEC_ARCHIVE_URL} && \
     mkdir /downloads/ecommerce && \
     tar xzf ecommerce.tgz -C /downloads/ecommerce --strip-components=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,8 @@ COPY --from=front-builder /home/node/ecommerce/static /app/ecommerce/static
 # container, so we should override it in our ECOMMERCE_CFG file.
 COPY ./docker/files/usr/local/etc/ecommerce /usr/local/etc/ecommerce
 ENV ECOMMERCE_CFG /usr/local/etc/ecommerce/local.yaml
-RUN python manage.py update_assets --skip-collect --settings=ecommerce.settings.production
+RUN python manage.py update_assets --skip-collect --settings=ecommerce.settings.production || \
+      echo "Assets update failed and will be ignored (old release)"
 
 # Copy default entrypoint script
 COPY ./docker/files/usr/local/bin/entrypoint /usr/local/bin/entrypoint

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # OpenEdx E-Commerce
-EDX_EC_RELEASE               ?= master
-EDX_EC_ARCHIVE_URL           ?= https://github.com/edx/ecommerce/archive/master.tar.gz
-FLAVOR                       ?= bare
-FLAVORED_EDX_EC_RELEASE_PATH  = releases/$(shell echo ${EDX_EC_RELEASE} | sed -E "s|\.|/|")/$(FLAVOR)
-EDX_EC_RELEASE_REF           ?= master
-EDX_EC_DOCKER_TAG            ?= latest
+EDXEC_RELEASE               ?= master
+EDXEC_ARCHIVE_URL           ?= https://github.com/edx/ecommerce/archive/master.tar.gz
+FLAVOR                      ?= bare
+FLAVORED_EDXEC_RELEASE_PATH  = releases/$(shell echo ${EDXEC_RELEASE} | sed -E "s|\.|/|")/$(FLAVOR)
+EDXEC_RELEASE_REF           ?= master
+EDXEC_DOCKER_TAG            ?= latest
 
 # Get local user ids
 DOCKER_UID = $(shell id -u)
@@ -14,7 +14,7 @@ DOCKER_GID = $(shell id -g)
 COMPOSE          = \
   DOCKER_UID=$(DOCKER_UID) \
   DOCKER_GID=$(DOCKER_GID) \
-  FLAVORED_EDX_EC_RELEASE_PATH=$(FLAVORED_EDX_EC_RELEASE_PATH) \
+  FLAVORED_EDXEC_RELEASE_PATH=$(FLAVORED_EDXEC_RELEASE_PATH) \
   docker-compose
 COMPOSE_RUN      = $(COMPOSE) run --rm -e HOME="/tmp"
 COMPOSE_EXEC     = $(COMPOSE) exec
@@ -34,22 +34,22 @@ SHELL=bash
 
 default: help
 
-$(FLAVORED_EDX_EC_RELEASE_PATH)/data/assets/.keep:
-	mkdir -p $(FLAVORED_EDX_EC_RELEASE_PATH)/data/assets
-	touch $(FLAVORED_EDX_EC_RELEASE_PATH)/data/assets/.keep
+$(FLAVORED_EDXEC_RELEASE_PATH)/data/assets/.keep:
+	mkdir -p $(FLAVORED_EDXEC_RELEASE_PATH)/data/assets
+	touch $(FLAVORED_EDXEC_RELEASE_PATH)/data/assets/.keep
 
-$(FLAVORED_EDX_EC_RELEASE_PATH)/data/media/.keep:
-	mkdir -p $(FLAVORED_EDX_EC_RELEASE_PATH)/data/media
-	touch $(FLAVORED_EDX_EC_RELEASE_PATH)/data/media/.keep
+$(FLAVORED_EDXEC_RELEASE_PATH)/data/media/.keep:
+	mkdir -p $(FLAVORED_EDXEC_RELEASE_PATH)/data/media
+	touch $(FLAVORED_EDXEC_RELEASE_PATH)/data/media/.keep
 
-$(FLAVORED_EDX_EC_RELEASE_PATH)/src/.keep:
-	mkdir -p $(FLAVORED_EDX_EC_RELEASE_PATH)/src
-	touch $(FLAVORED_EDX_EC_RELEASE_PATH)/src/.keep
+$(FLAVORED_EDXEC_RELEASE_PATH)/src/.keep:
+	mkdir -p $(FLAVORED_EDXEC_RELEASE_PATH)/src
+	touch $(FLAVORED_EDXEC_RELEASE_PATH)/src/.keep
 
-$(FLAVORED_EDX_EC_RELEASE_PATH)/src/README.rst:
+$(FLAVORED_EDXEC_RELEASE_PATH)/src/README.rst:
 	@echo -e "$(COLOR_INFO)Downloading sources archive...$(COLOR_RESET)"
-	curl -sLo /tmp/ecommerce.tgz $(EDX_EC_ARCHIVE_URL)
-	tar xzf /tmp/ecommerce.tgz -C $(FLAVORED_EDX_EC_RELEASE_PATH)/src --strip-components=1
+	curl -sLo /tmp/ecommerce.tgz $(EDXEC_ARCHIVE_URL)
+	tar xzf /tmp/ecommerce.tgz -C $(FLAVORED_EDXEC_RELEASE_PATH)/src --strip-components=1
 
 bootstrap: \
   clean \
@@ -75,9 +75,9 @@ clean:  ## Remove downloaded sources, assets and database
 	${MAKE} stop
 	$(COMPOSE) rm mysql
 	@echo -e "$(COLOR_WARNING)Removing downloaded sources...$(COLOR_RESET)"
-	rm -fr $(FLAVORED_EDX_EC_RELEASE_PATH)/src
+	rm -fr $(FLAVORED_EDXEC_RELEASE_PATH)/src
 	@echo -e "$(COLOR_WARNING)Removing collected assets...$(COLOR_RESET)"
-	rm -fr $(FLAVORED_EDX_EC_RELEASE_PATH)/data
+	rm -fr $(FLAVORED_EDXEC_RELEASE_PATH)/data
 .PHONY: clean
 
 dev: info
@@ -102,12 +102,12 @@ dev-assets:  ## Handle development assets
 info:  ## Get activated release info
 	@echo -e "\n.:: OPENEDX-ECOMMERCE-DOCKER ::.\n"
 	@echo -e "== Active configuration ==\n"
-	@echo -e "* EDX_EC_RELEASE                : $(COLOR_INFO)$(EDX_EC_RELEASE)$(COLOR_RESET)"
+	@echo -e "* EDXEC_RELEASE                : $(COLOR_INFO)$(EDXEC_RELEASE)$(COLOR_RESET)"
 	@echo -e "* FLAVOR                        : $(COLOR_INFO)$(FLAVOR)$(COLOR_RESET)"
-	@echo -e "* FLAVORED_EDX_EC_RELEASE_PATH  : $(COLOR_INFO)$(FLAVORED_EDX_EC_RELEASE_PATH)$(COLOR_RESET)"
-	@echo -e "* EDX_EC_ARCHIVE_URL            : $(COLOR_INFO)$(EDX_EC_ARCHIVE_URL)$(COLOR_RESET)"
-	@echo -e "* EDX_EC_RELEASE_REF            : $(COLOR_INFO)$(EDX_EC_RELEASE_REF)$(COLOR_RESET)"
-	@echo -e "* EDX_EC_DOCKER_TAG             : $(COLOR_INFO)$(EDX_EC_DOCKER_TAG)$(COLOR_RESET)"
+	@echo -e "* FLAVORED_EDXEC_RELEASE_PATH  : $(COLOR_INFO)$(FLAVORED_EDXEC_RELEASE_PATH)$(COLOR_RESET)"
+	@echo -e "* EDXEC_ARCHIVE_URL            : $(COLOR_INFO)$(EDXEC_ARCHIVE_URL)$(COLOR_RESET)"
+	@echo -e "* EDXEC_RELEASE_REF            : $(COLOR_INFO)$(EDXEC_RELEASE_REF)$(COLOR_RESET)"
+	@echo -e "* EDXEC_DOCKER_TAG             : $(COLOR_INFO)$(EDXEC_DOCKER_TAG)$(COLOR_RESET)"
 	@echo -e ""
 .PHONY: info
 
@@ -117,7 +117,7 @@ logs:  ## Follow application logs
 
 fetch-src: \
   tree\
-  $(FLAVORED_EDX_EC_RELEASE_PATH)/src/README.rst
+  $(FLAVORED_EDXEC_RELEASE_PATH)/src/README.rst
 fetch-src:  ## Fetch OpenEdx ECommerce sources
 	@echo -e "$(COLOR_INFO)\
 	OpenEdx ECommerce project sources have been downloaded. \
@@ -141,9 +141,9 @@ stop:  ## Stop development server
 .PHONY: stop
 
 tree: \
-  $(FLAVORED_EDX_EC_RELEASE_PATH)/data/assets/.keep \
-  $(FLAVORED_EDX_EC_RELEASE_PATH)/data/media/.keep \
-  $(FLAVORED_EDX_EC_RELEASE_PATH)/src/.keep
+  $(FLAVORED_EDXEC_RELEASE_PATH)/data/assets/.keep \
+  $(FLAVORED_EDXEC_RELEASE_PATH)/data/media/.keep \
+  $(FLAVORED_EDXEC_RELEASE_PATH)/src/.keep
 tree:  ## Build working tree
 .PHONY: tree
 

--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,9 @@ dev-assets:  ## Handle development assets
 	@echo -e "$(COLOR_INFO)Handling assets for development...$(COLOR_RESET)"
 	$(COMPOSE_RUN) node npm install
 	$(COMPOSE_RUN) node node_modules/.bin/bower install
-	$(MANAGE) update_assets --skip-collect
+	$(MANAGE) update_assets --skip-collect || echo "Assets update failed and will be ignored (old release)"
 	$(COMPOSE_RUN) node node_modules/.bin/r.js -o build.js
-	$(MANAGE) collectstatic --no-input
+	$(MANAGE) collectstatic --noinput
 	$(MANAGE) compress --force
 .PHONY: dev-assets
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Select an available flavored release to activate:
 Your choice: 1
 
 # Copy/paste dogwood/3/fun environment:
-export EDX_EC_RELEASE=dogwood.3
+export EDXEC_RELEASE=dogwood.3
 export FLAVOR=fun
-export EDX_EC_ARCHIVE_URL=https://github.com/openfun/ecommerce/archive/dogwood.3.tar.gz
-export EDX_EC_RELEASE_REF=dogwood.3-fun
-export EDX_EC_DOCKER_TAG=dogwood.3-fun
+export EDXEC_ARCHIVE_URL=https://github.com/openfun/ecommerce/archive/dogwood.3.tar.gz
+export EDXEC_RELEASE_REF=dogwood.3-fun
+export EDXEC_DOCKER_TAG=dogwood.3-fun
 
 # Or run the following command:
 . bin/../releases/dogwood/3/fun/activate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenEdx ECommerce Docker
+# OpenEdx E-Commerce Docker
 
 ## Prerequisite
 
@@ -9,15 +9,42 @@
 ## Getting started
 
 The aim of the project is to build the OpenEdx E-Commerce service Docker image
-and start playing with it locally. So let's play:
+and start playing with it locally.
+
+First, you need to choose a release/flavor of OpenEdx E-Commerce versions we
+support. You can list them and get instructions about how to select/activate a
+target release using the `bin/activate` script. An example output follows:
+
+```bash
+$ bin/activate
+Select an available flavored release to activate:
+[1] dogwood/3/fun (default)
+[2] master/bare
+Your choice: 1
+
+# Copy/paste dogwood/3/fun environment:
+export EDX_EC_RELEASE=dogwood.3
+export FLAVOR=fun
+export EDX_EC_ARCHIVE_URL=https://github.com/openfun/ecommerce/archive/dogwood.3.tar.gz
+export EDX_EC_RELEASE_REF=dogwood.3-fun
+export EDX_EC_DOCKER_TAG=dogwood.3-fun
+
+# Or run the following command:
+. bin/../releases/dogwood/3/fun/activate
+
+# Check your environment with:
+make info
+```
+
+Once your environment is set, start the full project by running:
 
 ```bash
 $ make bootstrap
 ```
 
-This will download an archive of the openedx project sources (current `master`
-branch state by default), build the docker image using downloaded sources,
-compile assets and run database migrations.
+This will download an archive of the OpenEdx E-Commerce project sources
+(current `master` branch state by default), build the docker image using
+downloaded sources, compile assets and run database migrations.
 
 After few minutes, the E-Commerce service should be built and configured. Now
 it's time to run it:
@@ -40,81 +67,6 @@ For more information about available commands, see:
 ```bash
 $ make help
 ```
-
-## Building a target release
-
-To build a particular release, you have to set two environment variables:
-
-- `EDX_EC_ARCHIVE_URL`: an URL pointing to a gzip tarball archive of the release sources
-- `EDX_EC_DOCKER_TAG`: the tag of the Docker image to build
-
-You may proceed as follows:
-
-```bash
-$ export EDX_EC_ARCHIVE_URL="https://github.com/edx/ecommerce/archive/open-release/ironwood.2.tar.gz"
-$ export EDX_EC_DOCKER_TAG="open-release-ironwood.2"
-```
-
-Once defined in your shell, make sure that it is taken into account using the
-Makefile's `info` target:
-
-```bash
-$ make info
-
-.:: OPENEDX-ECOMMERCE-DOCKER ::.
-
-== Active configuration ==
-
-* EDX_EC_ARCHIVE_URL: https://github.com/edx/ecommerce/archive/open-release/ironwood.2.tar.gz
-* EDX_EC_RELEASE_REF: open-release/ironwood.2
-* EDX_EC_DOCKER_TAG : open-release-ironwood.2
-```
-
-As it may be tedious to define such environment variables, we've cooked a
-helper for that. Take a look at the `bin/activate` script:
-
-```
-Usage: bin/activate [RELEASE_REF|ARCHIVE_URL]
-```
-
-This script accepts one single required argument that may be an edx/ecommerce
-Git reference (tag or branch name from the official repository) or an URL
-pointing to a gzip tarball archive of the ecommerce application sources.
-
-This argument may be:
-
-- `RELEASE_REF`: the release reference to build (always targeting the official repository), or,
-- `ARCHIVE_URL`: the release sources archive URL (may target any repository)
-
-Here some examples usage:
-
-```
-$ bin/activate master
-$ bin/activate open-release/ironwood.2
-$ bin/activate https://github.com/openfun/ecommerce/archive/fun/ecommerce-ol.tar.gz
-```
-
-The script output should look like the following, _i.e._ a list of environment
-variables definition:
-
-```
-export EDX_EC_ARCHIVE_URL=https://github.com/edx/ecommerce/archive/open-release/ironwood.2.tar.gz
-export EDX_EC_RELEASE_REF=open-release/ironwood.2
-export EDX_EC_DOCKER_TAG=open-release-ironwood.2
-```
-
-You may want to copy/paste the activate script output to set your shell
-environment or use the following one-liner using [Bash process
-substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html#Process-Substitution):
-
-```
-$ source <(bin/activate open-release/ironwood.2)
-```
-
-Now that your environment is properly set, you need to bootstrap the project
-once again (see "Getting started" section). Note that by bootstrapping the
-project, the content of local volumes (`data/`, `src/`i, ...) and databases
-will be dropped using the `clean` Makefile target.
 
 ## License
 

--- a/bin/activate
+++ b/bin/activate
@@ -1,68 +1,83 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+declare ENV_FILENAME
+declare PROJECT_DIRECTORY
+declare RELEASES_ROOT
 
-# usage: display usage with the appropriate exit code
-#
-# usage: usage [EXIT_CODE]
-#
-#   EXIT_CODE: program exit code (default: 0)
-function usage(){
+ENV_FILENAME="activate"
+PROJECT_DIRECTORY="$(dirname "${BASH_SOURCE[0]}")/.."
+RELEASES_ROOT="${PROJECT_DIRECTORY}/releases"
 
-    declare -i exit_code="${1:-0}"
 
-    echo "Usage: bin/activate [RELEASE_REF|ARCHIVE_URL]
+function select_release(){
 
-This script accepts one single required argument that may be an edx/ecommerce
-git reference (tag or branch name from the official repository) or an URL
-pointing to a gzip tarball archive of the ecommerce application sources.
+    declare prompt
+    declare release
+    declare -a releases
+    declare -i default=1
+    declare -i choice
+    declare -i n_releases
 
-Argument:
+    # List releases by looking for activate scripts in the "releases" directory and
+    # store them in the releases array
+    read -r -a releases <<< $(
+        find "${PROJECT_DIRECTORY}/releases/" -maxdepth 4 -name activate |
+        sed "s|${PROJECT_DIRECTORY}/releases/\\(.*\\)/activate|\\1|g" |
+        xargs
+    )
+    n_releases=${#releases[@]}
 
-  RELEASE_REF  the release reference to build (always targeting the official repository)
-or
-  ARCHIVE_URL  the release sources archive URL (may target any repository)
+    prompt="Select an available flavored release to activate:\\n"
+    for (( i=0; i<n_releases; i++ )); do
+        prompt+="[$((i+1))] ${releases[$i]}"
+        if [[ $((i+1)) -eq ${default} ]]; then
+            prompt+=" (default)"
+        fi
+        prompt+="\\n"
+    done
+    prompt+="Your choice: "
+    read -r -p "$(echo -e "${prompt}")" choice
 
-Examples:
+    if [[ ${choice} -gt n_releases ]]; then
+        (>&2 echo "Invalid choice ${choice} (should be <= ${n_releases})")
+        exit 10
+    fi
 
-  bin/activate master
-  bin/activate open-release/ironwood.2
-  bin/activate https://github.com/openfun/ecommerce/archive/fun/ecommerce-ol.tar.gz
+    if [[ ${choice} -le 0 ]]; then
+        choice=${default}
+    fi
 
-Output:
-
-  export EDX_EC_ARCHIVE_URL=https://github.com/edx/ecommerce/archive/open-release/ironwood.2.tar.gz
-  export EDX_EC_RELEASE_REF=open-release/ironwood.2
-  export EDX_EC_DOCKER_TAG=open-release-ironwood.2
-
-You may want to copy/paste the activate script output to set your shell
-environment or use the following one-liner using Bash process substitution:
-
-  $ source <(bin/activate open-release/ironwood.2)
-"
-
-    # shellcheck disable=SC2086
-    exit ${exit_code}
+    release="${releases[$((choice-1))]}"
+    echo "${release}"
 }
 
-# ---- Main ----
-if [[ ${#} -ne 1 ]]; then
-  usage 1
-fi
 
-declare archive_url
-declare release_ref
+function activate_release(){
 
-if [[ ${1} == http* ]]; then
-  # Use a two steps parameter subsitution to get the reference from an URL.
-  # Known limitation: we expect the archive to be hosted on github.
-  release_ref=$(tmp=${1#*/github.com/*/ecommerce/archive/} && echo "${tmp%%.tar.gz}")
-  archive_url=${1}
-else
-  release_ref=${1}
-  archive_url="https://github.com/edx/ecommerce/archive/${release_ref}.tar.gz"
-fi
+    declare release="$1"
 
-echo "export EDX_EC_ARCHIVE_URL=${archive_url}"
-echo "export EDX_EC_RELEASE_REF=${release_ref}"
-echo "export EDX_EC_DOCKER_TAG=${release_ref/\//-}"
+    release_path="${RELEASES_ROOT}/${release}"
+    env_file_path="${release_path}/${ENV_FILENAME}"
+
+    if [[ ! -d ${release_path} ]]; then
+        (>&2 echo "Release path ${release_path} doesn't exists!")
+        exit 20
+    fi
+
+    if [[ ! -e ${env_file_path} ]]; then
+        (>&2 echo "Environment file (${ENV_FILENAME}) not found for this release!")
+        exit 21
+    fi
+
+    echo -e "\\n# Copy/paste ${release} environment:"
+    cat "${env_file_path}"
+
+    echo -e "\\n# Or run the following command:"
+    echo -e ". ${env_file_path}"
+
+    echo -e "\\n# Check your environment with:"
+    echo -e "make info"
+}
+
+release=$(select_release)
+activate_release "${release}"

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# usage: display usage with the appropriate exit code
+#
+# usage: usage [EXIT_CODE]
+#
+#   EXIT_CODE: program exit code (default: 0)
+function usage(){
+
+    declare -i exit_code="${1:-0}"
+
+    echo "Usage: bin/ci COMMAND
+
+Available commands:
+
+  activate_path    display CIRCLE_TAG (or CIRCLE_JOB) release activate script path
+  checkpoint       skip release job if changes are not targeting the current release
+  get_changes      get a list of changed files in the current branch compared to master
+  test             test the application server response
+"
+
+    # shellcheck disable=SC2086
+    exit ${exit_code}
+}
+
+# Get active release activation path given the CIRCLE_TAG or CIRCLE_JOB
+# environment variable. If both are defined the CIRCLE_TAG variable will
+# prevail.
+function activate_path(){
+
+  declare reference
+  declare release
+
+  reference=${CIRCLE_TAG:-${CIRCLE_JOB}}
+  if [[ -z ${reference} ]]; then
+    (>&2 echo "CIRCLE_TAG or CIRCLE_JOB environment variable should be defined!")
+    exit 20
+  fi
+
+  # We need to convert the reference (_e.g._ something like hawthorn.1-1.0.3 or dogwood.3-fun)
+  # to a flavored release path (e.g. something like hawthorn/1/bare or dogwood/3/fun for the
+  # later examples). In the following, we have a three-steps pipeline
+  # to do so: i. get the release name, number and optionally a flavor from the
+  # reference, ii. in case of empty release number and/or flavor, our sed
+  # substitution will generate duplicated slashes that should be fixed, and
+  # iii.  the default flavor (empty third group from our regular expression)
+  # should be named "bare".
+  release=$(\
+    echo "${reference}" | \
+    sed -E 's|^([a-z]*)\.?([0-9]*)-?([a-z]*)?(-[0-9.]+)?$|\1/\2/\3|g' | \
+    sed -E 's|//|/|g' | \
+    sed -E 's|/$|/bare|g'
+  )
+
+  echo "releases/${release}/activate"
+}
+
+# Skip release job if changes are not targeting the current release
+function checkpoint(){
+
+  changes=$(get_changes)
+
+  if echo "${changes}" | grep -v "releases/" > /dev/null ; then
+    (>&2 echo "Current work scope is global, all releases should build.")
+    exit 0
+  fi
+
+  release_path=$(activate_path | sed -E 's|/activate$||')
+
+  if ! echo "${changes}" | grep "${release_path}" > /dev/null ; then
+    (>&2 echo "Skipping release (out of scope).")
+    circleci-agent step halt
+  fi
+}
+
+# Get a list of changed files in the current branch
+function get_changes() {
+
+    git whatchanged --name-only --pretty="" "origin/master..HEAD" | sort -u
+}
+
+# ---- Main ----
+
+# Check if this script is being sourced or executed. Explanation: Bash allows
+# return statements only from functions and, in a script's top-level scope, only
+# if the script is sourced.
+(return 2> /dev/null) && sourced=1 || sourced=0
+
+if [[ ${sourced} == 0 ]]; then
+
+    action="${1:-usage}"
+
+    # Remove current action from arguments array
+    if [[ -n "${1}" ]]; then
+        shift
+    fi
+
+    "$action" "$@"
+fi
+

--- a/bin/compose
+++ b/bin/compose
@@ -2,15 +2,15 @@
 
 DOCKER_UID=$(id -u)
 DOCKER_GID=$(id -g)
-EDX_EC_ARCHIVE_URL=${EDX_EC_ARCHIVE_URL:-https://github.com/edx/ecommerce/archive/master.tar.gz}
-EDX_EC_RELEASE_REF=${EDX_EC_RELEASE_REF:-master}
-EDX_EC_DOCKER_TAG=${EDX_EC_DOCKER_TAG:-latest}
+EDXEC_ARCHIVE_URL=${EDXEC_ARCHIVE_URL:-https://github.com/edx/ecommerce/archive/master.tar.gz}
+EDXEC_RELEASE_REF=${EDXEC_RELEASE_REF:-master}
+EDXEC_DOCKER_TAG=${EDXEC_DOCKER_TAG:-latest}
 
 
 export DOCKER_UID
 export DOCKER_GID
-export EDX_EC_ARCHIVE_URL
-export EDX_EC_RELEASE_REF
-export EDX_EC_DOCKER_TAG
+export EDXEC_ARCHIVE_URL
+export EDXEC_RELEASE_REF
+export EDXEC_DOCKER_TAG
 
 docker-compose "${@}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,9 @@ services:
     ports:
         - "8000:8000"
     volumes:
-      - ./src:/app
-      - ./data/assets:/app/assets
-      - ./data/media:/app/media
+      - ./${FLAVORED_EDX_EC_RELEASE_PATH:-releases/master/bare}/src:/app
+      - ./${FLAVORED_EDX_EC_RELEASE_PATH:-releases/master/bare}/data/assets:/app/assets
+      - ./${FLAVORED_EDX_EC_RELEASE_PATH:-releases/master/bare}/data/media:/app/media
       - ./docker/files/usr/local/etc/ecommerce:/usr/local/etc/ecommerce
     command: python manage.py runserver 0.0.0.0:8000
     depends_on:
@@ -34,7 +34,7 @@ services:
     image: node:10
     user: ${DOCKER_UID:-1000}:${DOCKER_GID:-1000}
     volumes:
-      - ./src:/app
+      - ./${FLAVORED_EDX_EC_RELEASE_PATH:-releases/master/bare}/src:/app
     working_dir: /app
 
   dockerize:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,16 +15,16 @@ services:
       args:
         DOCKER_UID: ${DOCKER_UID:-1000}
         DOCKER_GID: ${DOCKER_GID:-1000}
-        EDX_EC_ARCHIVE_URL: ${EDX_EC_ARCHIVE_URL:-https://github.com/edx/ecommerce/archive/master.tar.gz}
-    image: edxec:${EDX_EC_DOCKER_TAG:-latest}
+        EDXEC_ARCHIVE_URL: ${EDXEC_ARCHIVE_URL:-https://github.com/edx/ecommerce/archive/master.tar.gz}
+    image: edxec:${EDXEC_DOCKER_TAG:-latest}
     env_file:
         - env.d/development/app
     ports:
         - "8000:8000"
     volumes:
-      - ./${FLAVORED_EDX_EC_RELEASE_PATH:-releases/master/bare}/src:/app
-      - ./${FLAVORED_EDX_EC_RELEASE_PATH:-releases/master/bare}/data/assets:/app/assets
-      - ./${FLAVORED_EDX_EC_RELEASE_PATH:-releases/master/bare}/data/media:/app/media
+      - ./${FLAVORED_EDXEC_RELEASE_PATH:-releases/master/bare}/src:/app
+      - ./${FLAVORED_EDXEC_RELEASE_PATH:-releases/master/bare}/data/assets:/app/assets
+      - ./${FLAVORED_EDXEC_RELEASE_PATH:-releases/master/bare}/data/media:/app/media
       - ./docker/files/usr/local/etc/ecommerce:/usr/local/etc/ecommerce
     command: python manage.py runserver 0.0.0.0:8000
     depends_on:
@@ -34,7 +34,7 @@ services:
     image: node:10
     user: ${DOCKER_UID:-1000}:${DOCKER_GID:-1000}
     volumes:
-      - ./${FLAVORED_EDX_EC_RELEASE_PATH:-releases/master/bare}/src:/app
+      - ./${FLAVORED_EDXEC_RELEASE_PATH:-releases/master/bare}/src:/app
     working_dir: /app
 
   dockerize:

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html) for each flavored OpenEdx
+release.
+
+## [Unreleased]
+
+## [dogwood.3-fun-1.0.0] - 2020-01-06
+
+### Added
+
+- First experimental release of OpenEdx E-Commerce `dogwood.3` (fun flavor).
+
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.0.0...HEAD
+[dogwood.3-fun-1.0.0]: https://github.com/openfun/openedx-docker/releases/tag/dogwood.3-fun-1.0.0

--- a/releases/dogwood/3/fun/activate
+++ b/releases/dogwood/3/fun/activate
@@ -1,0 +1,5 @@
+export EDX_EC_RELEASE=dogwood.3
+export FLAVOR=fun
+export EDX_EC_ARCHIVE_URL=https://github.com/openfun/ecommerce/archive/dogwood.3.tar.gz
+export EDX_EC_RELEASE_REF=dogwood.3-fun
+export EDX_EC_DOCKER_TAG=dogwood.3-fun

--- a/releases/dogwood/3/fun/activate
+++ b/releases/dogwood/3/fun/activate
@@ -1,5 +1,5 @@
-export EDX_EC_RELEASE=dogwood.3
+export EDXEC_RELEASE=dogwood.3
 export FLAVOR=fun
-export EDX_EC_ARCHIVE_URL=https://github.com/openfun/ecommerce/archive/dogwood.3.tar.gz
-export EDX_EC_RELEASE_REF=dogwood.3-fun
-export EDX_EC_DOCKER_TAG=dogwood.3-fun
+export EDXEC_ARCHIVE_URL=https://github.com/openfun/ecommerce/archive/dogwood.3.tar.gz
+export EDXEC_RELEASE_REF=dogwood.3-fun
+export EDXEC_DOCKER_TAG=dogwood.3-fun

--- a/releases/master/bare/CHANGELOG.md
+++ b/releases/master/bare/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html) for each flavored OpenEdx
+release.
+
+> Do not expect changes to be logged here as we might never make a release from
+> the OpenEdx E-Commerce `master` releases. The aim of this flavor is to test
+> changes we must expect from a future release.
+
+## [Unreleased]
+
+[unreleased]: https://github.com/openfun/openedx-ecommerce-docker
+

--- a/releases/master/bare/activate
+++ b/releases/master/bare/activate
@@ -1,5 +1,5 @@
-export EDX_EC_RELEASE=master
+export EDXEC_RELEASE=master
 export FLAVOR=bare
-export EDX_EC_ARCHIVE_URL=https://github.com/edx/ecommerce/archive/master.tar.gz
-export EDX_EC_RELEASE_REF=master
-export EDX_EC_DOCKER_TAG=master
+export EDXEC_ARCHIVE_URL=https://github.com/edx/ecommerce/archive/master.tar.gz
+export EDXEC_RELEASE_REF=master
+export EDXEC_DOCKER_TAG=master

--- a/releases/master/bare/activate
+++ b/releases/master/bare/activate
@@ -1,0 +1,5 @@
+export EDX_EC_RELEASE=master
+export FLAVOR=bare
+export EDX_EC_ARCHIVE_URL=https://github.com/edx/ecommerce/archive/master.tar.gz
+export EDX_EC_RELEASE_REF=master
+export EDX_EC_DOCKER_TAG=master


### PR DESCRIPTION
## Purpose

We need to be able to build multiple e-commerce releases from the same repository similarly to our openedx-docker project.

## Proposal

- [x] add a `releases/` tree
- [x] update docker-compose release in the CI
- [x] update documentation