### PR TITLE
✨(ironwood/2/bare) add ironwood.2 offical release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,9 @@ jobs:
   dogwood.3-fun:
     <<: [*defaults, *build_steps]
 
+  ironwood.2-bare:
+    <<: [*defaults, *build_steps]
+
   # Hub job
   hub:
     <<: *defaults
@@ -189,6 +192,10 @@ workflows:
             tags:
               ignore: /.*/
       - dogwood.3-fun:
+          filters:
+            tags:
+              ignore: /.*/
+      - ironwood.2-bare:
           filters:
             tags:
               ignore: /.*/

--- a/releases/ironwood/2/bare/CHANGELOG.md
+++ b/releases/ironwood/2/bare/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html) for each flavored OpenEdx
+release.
+
+## [Unreleased]
+
+## [ironwood.2-1.0.0] - 2020-01-08
+
+### Added
+
+- First experimental release of OpenEdx E-Commerce `ironwood` (bare flavor).
+
+[unreleased]: https://github.com/openfun/openedx-docker/compare/ironwood.2-1.0.0...HEAD
+[ironwood.2-1.0.0]: https://github.com/openfun/openedx-docker/releases/tag/ironwood.2-1.0.0

--- a/releases/ironwood/2/bare/activate
+++ b/releases/ironwood/2/bare/activate
@@ -1,0 +1,5 @@
+export EDXEC_RELEASE=ironwood.2
+export FLAVOR=bare
+export EDXEC_ARCHIVE_URL=https://github.com/edx/ecommerce/archive/open-release/ironwood.2.tar.gz
+export EDXEC_RELEASE_REF=ironwood.2
+export EDXEC_DOCKER_TAG=ironwood.2


### PR DESCRIPTION
## Purpose

We need a recent official release to test Arnold's `edxec` tray (see https://github.com/openfun/arnold/pull/425). Using the `master` release would lead to unexpected failures of Arnold's CI as it's not a reproducible approach.

## Proposal

- [x] add `ironwood/2/bare` official release to supported releases
