### PR TITLE
Upgrade openedx ecommerce to dogwood.3-2021-10-01 and release fix

### DIFF
--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,11 +9,18 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-fun-1.0.1] - 2021-10-01
+
+### Fixed
+
+- Upgrade to OpenEdx E-Commerce `dogwood.3-2021-10-01` with LE certificate fix
+
 ## [dogwood.3-fun-1.0.0] - 2020-01-06
 
 ### Added
 
 - First experimental release of OpenEdx E-Commerce `dogwood.3` (fun flavor).
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.0.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.0.1...HEAD
+[dogwood.3-fun-1.0.1]: https://github.com/openfun/openedx-docker/compare/dogwood.3-fun-1.0.0...dogwood.3-fun-1.0.1
 [dogwood.3-fun-1.0.0]: https://github.com/openfun/openedx-docker/releases/tag/dogwood.3-fun-1.0.0

--- a/releases/dogwood/3/fun/activate
+++ b/releases/dogwood/3/fun/activate
@@ -1,5 +1,5 @@
 export EDXEC_RELEASE=dogwood.3
 export FLAVOR=fun
-export EDXEC_ARCHIVE_URL=https://github.com/openfun/ecommerce/archive/dogwood.3.tar.gz
+export EDXEC_ARCHIVE_URL=https://github.com/openfun/ecommerce/archive/dogwood.3-2021.10.01.tar.gz
 export EDXEC_RELEASE_REF=dogwood.3-fun
 export EDXEC_DOCKER_TAG=dogwood.3-fun


### PR DESCRIPTION

### Fixed

- Upgrade to OpenEdx E-Commerce `dogwood.3-2021-10-01` with LE certificate fix
